### PR TITLE
allow to use clang (if defined)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CC=gcc
+CC?=gcc
 COPTS=-O -g -Wall -Werror
 
 .PHONY: all clean


### PR DESCRIPTION
currently CC=gcc always, even if CC=clang in environment