### PR TITLE
osx initial support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,15 @@ language: c
 
 compiler:
   - gcc
-  - clang
 
 addons:
   apt:
     packages: [ python ]
 
-cache:
-  apt: true
+matrix:
+  include:
+    - os: osx
+      compiler: clang
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-CC=gcc
+CC?=gcc
 COPTS=-O -g -Wall -Werror
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-TESTENV=LD_PRELOAD=$(ROOT_DIR)/mockeagain.so MOCKEAGAIN_VERBOSE=1
-ALL_TESTS=$(shell find t/ -regextype sed -regex 't/[0-9]\{3\}.*\.c')
+TESTENV=LD_PRELOAD=$(ROOT_DIR)/mockeagain.so DYLD_INSERT_LIBRARIES=$(ROOT_DIR)/mockeagain.so DYLD_FORCE_FLAT_NAMESPACE=1 MOCKEAGAIN_VERBOSE=1
+ALL_TESTS=$(shell find t -name "[0-9]*.c")
 VALGRIND:=0
 
 .PHONY: all test clean

--- a/t/000-mock-writes.c
+++ b/t/000-mock-writes.c
@@ -1,4 +1,5 @@
 #include "test_case.h"
+#include <sys/uio.h>
 
 int run_test(int fd) {
     int n;


### PR DESCRIPTION
```
(*) apt caching actually never worked
(*) "CC=gcc" seems strange even with original matrix (why to choose gcc+clang in such case ?)
(*) writev requires include on osx
(*) find on osx is not the same as find on linux
```

well, I've yet not figured out why test is failing on osx, it would be nice if you will help me.

actually, I'm trying to add travis-ci/osx to lua-nginx-module, currently I figured out that mockeagain does not fit well.