### PR TITLE
feature: avoided mocking EAGAIN with POLLHUP event.

### DIFF
--- a/mockeagain.c
+++ b/mockeagain.c
@@ -600,7 +600,7 @@ read(int fd, void *buf, size_t len)
     if ((get_mocking_type() & MOCKING_READS)
         && fd <= MAX_FD
         && polled_fds[fd]
-        && !(active_fds[fd] & POLLIN))
+        && !(active_fds[fd] & (POLLIN | POLLHUP)))
     {
         if (get_verbose_level()) {
             fprintf(stderr, "mockeagain: mocking \"read\" on fd %d to "


### PR DESCRIPTION
When the pipe fd is closed, poll will report a POLLHUP event.
In this case, if we still mock the read syscall to return EAGAIN, it
will cause an infinite loop.