### PR TITLE
tests: use Python to directly pass environment variables to runner to

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 CC?=gcc
 COPTS=-O -g -Wall -Werror
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-TESTENV=LD_PRELOAD=$(ROOT_DIR)/mockeagain.so DYLD_INSERT_LIBRARIES=$(ROOT_DIR)/mockeagain.so DYLD_FORCE_FLAT_NAMESPACE=1 MOCKEAGAIN_VERBOSE=1
 ALL_TESTS=$(shell find t -name "[0-9]*.c")
 VALGRIND:=0
 
@@ -14,11 +13,10 @@ all: mockeagain.so
 	$(CC) $(COPTS) -fPIC -shared $< -o $@
 
 test: all $(ALL_TESTS)
-	export $(TESTENV); \
 	for t in $(ALL_TESTS); do \
 		$(CC) $(COPTS) -o ./t/runner $$t ./t/runner.c ./t/test_case.c \
 		|| exit 1; \
-		python ./t/echo_server.py ./t/runner $(VALGRIND) \
+		python ./t/echo_server.py ./t/runner $(VALGRIND) $(ROOT_DIR)/mockeagain.so \
 		&& echo "Test case $$t passed" || exit 1; \
 	done
 

--- a/t/echo_server.py
+++ b/t/echo_server.py
@@ -33,13 +33,19 @@ if __name__ == "__main__":
     server_thread.start()
 
     print('Listening on IP %s and port %d' % server.server_address)
+    env = {
+              "LD_PRELOAD": sys.argv[3],
+              "DYLD_INSERT_LIBRARIES": sys.argv[3],
+              "DYLD_FORCE_FLAT_NAMESPACE": "1",
+              "MOCKEAGAIN_VERBOSE": "1",
+          }
 
-    if len(sys.argv) == 3 and sys.argv[2] == '1': # valgrind
+    if len(sys.argv) == 4 and sys.argv[2] == '1': # valgrind
         ret = subprocess.call(['valgrind', '--leak-check=full',
                                sys.argv[1], server.server_address[0],
-                               str(server.server_address[1])])
+                               str(server.server_address[1])], env=env)
     else:
         ret = subprocess.call([sys.argv[1], server.server_address[0],
-                              str(server.server_address[1])])
+                              str(server.server_address[1])], env=env)
 
     sys.exit(ret)


### PR DESCRIPTION
avoid DYLD_INSERT_LIBRARIES being ignored for SIP-protected binaries.
See: https://github.com/wolfcw/libfaketime/issues/99#issuecomment-257157062

System Integrity Protection (SIP) is a new macOS feature added in El Capitan that will filter out `DYLD_INSERT_LIBRARIES` passed to protected system binaries (this includes the `python` interpreter) causing hooking to fail. Instead we pass the environment flags directly when forking to avoid this problem. Tests now runs happily on OS X.